### PR TITLE
fix const WeeklySummaryChart 

### DIFF
--- a/src/app/category/record/page.tsx
+++ b/src/app/category/record/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Footer from "@/app/components/layout/Footer";
-import WeeklySummaryChart from "@/components/ui/TrainingChart";
 import React, { useState } from "react";
+import dynamic from "next/dynamic";
 
 // 初期値を現在日を含む週の開始日に設定するヘルパー関数
 function getWeekStartDate(date: Date) {
@@ -15,6 +15,13 @@ function getWeekStartDate(date: Date) {
   console.log("startDate", startDate);
   return startDate.toISOString().split("T")[0]; // YYYY-MM-DD形式で返す
 }
+
+const WeeklySummaryChart = dynamic(
+  () => import("@/components/ui/TrainingChart"),
+  {
+    ssr: false, // このオプションにより、サーバーサイドレンダリングが無効になります
+  }
+);
 
 function RecordPage() {
   const [selectedDate, setSelectedDate] = useState(

--- a/src/components/ui/TrainingChart.tsx
+++ b/src/components/ui/TrainingChart.tsx
@@ -1,4 +1,3 @@
-'use client';
 import React from "react";
 import { Bar } from "react-chartjs-2";
 import "chart.js/auto";

--- a/src/components/ui/TrainingChart.tsx
+++ b/src/components/ui/TrainingChart.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React from "react";
 import { Bar } from "react-chartjs-2";
 import "chart.js/auto";
@@ -39,7 +40,9 @@ const options = {
         pinch: {
           enabled: true, // ピンチでのズームを有効化 (タッチデバイス用)
         },
-        mode: "x", // 'x' 軸方向にズーム
+        mode: (chart: any) => {
+          return "x";
+        }, // 'x' 軸方向にズーム
       },
     },
   },
@@ -69,7 +72,7 @@ const WeeklySummaryChart = ({ startDate }: { startDate: string }) => {
       },
     ],
   };
-  return <Bar data={chartData} />;
+  return <Bar options={options as any} data={chartData} />;
 };
 
 export default WeeklySummaryChart;

--- a/src/components/ui/TrainingChart.tsx
+++ b/src/components/ui/TrainingChart.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from "react";
 import { Bar } from "react-chartjs-2";
 import "chart.js/auto";

--- a/src/hooks/useWeeklySummary.ts
+++ b/src/hooks/useWeeklySummary.ts
@@ -1,3 +1,4 @@
+"use client";
 import useSWR from "swr";
 
 interface WeeklySummary {


### PR DESCRIPTION
TrainingChartのimportを下記に修正

const WeeklySummaryChart = dynamic(
  () => import("@/components/ui/TrainingChart"),
  {
    ssr: false, // このオプションにより、サーバーサイドレンダリングが無効になります
  }
);